### PR TITLE
Exit as an error so others programs can catch it

### DIFF
--- a/neofetch_win/main.py
+++ b/neofetch_win/main.py
@@ -18,7 +18,7 @@ def shell():
         args = parser.parse_args(shlex.split(arguments))
     except Exception as e:
         print(e)
-        sys.exit(0)
+        sys.exit(1)
 
     if args.version:
         print(neofetch_win.__version__)


### PR DESCRIPTION
The goal is to be able to catch invalid args as an error in automated scripts and programs.