### PR TITLE
fix UnicodeDecodeError

### DIFF
--- a/neofetch_win/neofetch.py
+++ b/neofetch_win/neofetch.py
@@ -104,7 +104,7 @@ class Neofetch:
 
         if self.art:
             try:
-                with open(self.art, "r") as f:
+                with open(self.art, "r", encoding="utf-8") as f:
                     lines = f.read().splitlines()
             except FileNotFoundError:
                 lines = art.windows_11


### PR DESCRIPTION
When I tried to use art, I got an error:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\Alex\AppData\Local\Programs\Python\Python312\Scripts\neofetch.exe\__main__.py", line 7, in <module>
  File "C:\Users\Alex\AppData\Local\Programs\Python\Python312\Lib\site-packages\neofetch_win\__main__.py", line 89, in main
    shell()
  File "C:\Users\Alex\AppData\Local\Programs\Python\Python312\Lib\site-packages\neofetch_win\__main__.py", line 83, in shell
    nf.pretty_print(ignore_list=args.ignore)
  File "C:\Users\Alex\AppData\Local\Programs\Python\Python312\Lib\site-packages\neofetch_win\neofetch.py", line 244, in pretty_print
    art = self.get_art()
          ^^^^^^^^^^^^^^
  File "C:\Users\Alex\AppData\Local\Programs\Python\Python312\Lib\site-packages\neofetch_win\neofetch.py", line 108, in get_art
    lines = f.read().splitlines()
            ^^^^^^^^
  File "C:\Users\Alex\AppData\Local\Programs\Python\Python312\Lib\encodings\cp1251.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 554: character maps to <undefined>
```

To fix this, I added encoding="utf-8"
![image](https://github.com/user-attachments/assets/cf8cfaee-39ba-400a-b363-19ce1455ce71)
![image](https://github.com/user-attachments/assets/0e85861a-0a94-4df0-9905-00fc41dbb5e4)
